### PR TITLE
Updated composer.json to allow installs on 2.3.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,25 +2,21 @@
   "name": "tech-solve/texttranslation",
   "description": "TechSolve TextTranslation",
   "require": {
-    "php": "~5.6.0|7.0.2|~7.0.6|~7.2",
-    "magento/framework": "0.74.0-beta4",
-    "magento/magento-composer-installer": "*"
+    "php": "~5.6.0|7.0.2|~7.0.6|~7.2|~7.3",
+    "magento/framework": ">=100"
   },
   "type": "magento2-module",
-  "version": "0.74.0-beta4",
+  "version": "0.74.0-beta5",
   "license": [
     "OSL-3.0",
     "AFL-3.0"
   ],
-  "extra": {
-    "map": [
-      [
-        "*",
-        "TechSolve/TextTranslation"
-      ]
-    ]
-  },
-  "config": {
-    "disable-tls": true
+  "autoload": {
+    "files": [
+      "TechSolve/TextTranslation/registration.php"
+    ],
+    "psr-4": {
+      "TechSolve\\TextTranslation\\": "TechSolve/TextTranslation"
+    }
   }
 }


### PR DESCRIPTION
Bring PHP version, Framework version and autoload up-to-date to allow this to be installed on the latest (2.3.5) Magento version.