### PR TITLE
Allow the page section to be left empty

### DIFF
--- a/TechSolve/TextTranslation/Block/Adminhtml/Translation/Edit/Tab/Main.php
+++ b/TechSolve/TextTranslation/Block/Adminhtml/Translation/Edit/Tab/Main.php
@@ -66,7 +66,7 @@ class Main extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     protected function _prepareForm()
     {
         /* @var $model \TechSolve\TextTranslation\Model\Translation */
-        
+
         $model = $this->_translation->create()->load($this->request->getParam('key_id'));
 
         $isElementDisabled = false;
@@ -140,9 +140,16 @@ class Main extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
             'name' => 'page_section',
             'label' => __(' Page Section'),
             'title' => __(' Page Section'),
-            'required' => true,
             'disabled' => $isElementDisabled,
-            'values' => ['Header'=>'Header','Footer'=>'Footer','Home page'=>'Home page','Listing page'=>'Listing page','Cart'=>'Cart','My account'=>'My account']
+            'values' => [
+                null=>' ',
+                'Header'=>'Header',
+                'Footer'=>'Footer',
+                'Home page'=>'Home page',
+                'Listing page'=>'Listing page',
+                'Cart'=>'Cart',
+                'My account'=>'My account'
+            ]
             ]
             );
 
@@ -205,7 +212,7 @@ class Main extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
     }
 
     public function getTargetOptionArray(){
-    	return array(
+        return array(
             '_self' => "Self",
             '_blank' => "New Page",
             );


### PR DESCRIPTION
The Database table supports "Null" page section, Magento itself allows this as well and uses this as a global translation.

Allow translations to be saved with an empty Page Section